### PR TITLE
Improve error heirarchy

### DIFF
--- a/src/into_dbus_python/_errors.py
+++ b/src/into_dbus_python/_errors.py
@@ -66,7 +66,7 @@ class IntoDPSurprisingError(IntoDPRuntimeError):
     libraries.
     """
 
-    def __init__(self, message, value):
+    def __init__(self, message, value):  # pragma: no cover
         """
         Initializer.
 

--- a/src/into_dbus_python/_errors.py
+++ b/src/into_dbus_python/_errors.py
@@ -22,27 +22,72 @@ class IntoDPError(Exception):
     """
 
 
-class IntoDPValueError(IntoDPError):
-    """ Raised when a parameter has an unacceptable value.
-
-        May also be raised when the parameter has an unacceptable type.
+class IntoDPGenerationError(IntoDPError):
     """
-    _FMT_STR = "value '%s' for parameter %s is unacceptable"
+    Exception raised during generation of a function.
+    """
 
-    def __init__(self, value, param, msg=None):  # pragma: no cover
-        """ Initializer.
 
-            :param object value: the value
-            :param str param: the parameter
-            :param str msg: an explanatory message
+class IntoDPImpossibleTokenError(IntoDPGenerationError):
+    """
+    Exception raised when an impossible token is encountered.
+    This should never occur, because the parser should fail.
+    """
+
+
+class IntoDPRuntimeError(IntoDPError):
+    """
+    Exception raised during execution of generated functions.
+    """
+
+
+class IntoDPUnexpectedValueError(IntoDPRuntimeError):
+    """
+    Exception raised when an unexpected value is encountered during a
+    transformation.
+    """
+
+    def __init__(self, message, value):
         """
-        # pylint: disable=super-init-not-called
-        self._value = value
-        self._param = param
-        self._msg = msg
+        Initializer.
 
-    def __str__(self):  # pragma: no cover
-        if self._msg:
-            fmt_str = self._FMT_STR + ": %s"
-            return fmt_str % (self._value, self._param, self._msg)
-        return self._FMT_STR % (self._value, self._param)
+        :param str message: the message
+        :param object value: the value encountered
+        """
+        super(IntoDPUnexpectedValueError, self).__init__(message)
+        self.value = value
+
+
+class IntoDPSurprisingError(IntoDPRuntimeError):
+    """
+    Exception raised when a surprising error is caught during a transformation.
+    Surprising errors can arise due to undocumented or incorrectly documented
+    behaviors of dependent libraries or bugs in this library or dependent
+    libraries.
+    """
+
+    def __init__(self, message, value):
+        """
+        Initializer.
+
+        :param str message: the message
+        :param object value: the value encountered
+        """
+        super(IntoDPSurprisingError, self).__init__(message)
+        self.value = value
+
+
+class IntoDPSignatureError(IntoDPError):
+    """
+    Exception raised when a value does not seem to have a valid signature.
+    """
+
+    def __init__(self, message, value):
+        """
+        Initializer.
+
+        :param str message: the message
+        :param object value: the problematic putative dbus-python object
+        """
+        super(IntoDPSignatureError, self).__init__(message)
+        self.value = value

--- a/src/into_dbus_python/_signature.py
+++ b/src/into_dbus_python/_signature.py
@@ -71,11 +71,15 @@ def signature(dbus_object, unpack=False):
         len_value_sigs = len(value_sigs)
 
         if len_key_sigs != len_value_sigs:
+            # It seems impossible to force a dbus-python Dictionary value
+            # to have this property; the Dictionary constructor prevents it.
             raise IntoDPSignatureError(
                 "the dbus-python Dictionary object %s does not have a valid signature"
                 % dbus_object, dbus_object)  # pragma: no cover
 
         if len_key_sigs > 1:
+            # It seems impossible to force a dbus-python Dictionary value
+            # to have this property; the Dictionary constructor prevents it.
             raise IntoDPSignatureError(
                 "the dbus-python Dictionary object %s has different signatures for different keys"
                 % dbus_object, dbus_object)  # pragma: no cover

--- a/src/into_dbus_python/_signature.py
+++ b/src/into_dbus_python/_signature.py
@@ -17,7 +17,7 @@ Definition of signature method.
 
 import dbus
 
-from ._errors import IntoDPValueError
+from ._errors import IntoDPSignatureError
 
 
 def signature(dbus_object, unpack=False):
@@ -33,15 +33,26 @@ def signature(dbus_object, unpack=False):
     # pylint: disable=too-many-return-statements
     # pylint: disable=too-many-branches
 
+    # This check is here for two reasons:
+    # The object passed may not be a dbus object, and consequently may not
+    # have a variant_level attribute. It may also be a UnixFd dbus object,
+    # which does not have a variant_level attribute. See bug:
+    # https://github.com/stratis-storage/into-dbus-python/issues/37.
+    if not hasattr(dbus_object, "variant_level"):
+        raise IntoDPSignatureError(
+            ("value does not have a variant_level attribute, "
+             "can not determine the correct signature"), dbus_object)
+
     if dbus_object.variant_level != 0 and not unpack:
         return 'v'
 
     if isinstance(dbus_object, dbus.Array):
         sigs = frozenset(signature(x) for x in dbus_object)
         len_sigs = len(sigs)
-        if len_sigs > 1:  # pragma: no cover
-            raise IntoDPValueError(dbus_object, "dbus_object",
-                                   "has bad signature")
+        if len_sigs > 1:
+            raise IntoDPSignatureError(
+                "the dbus-python Array object %s has items with varying signatures"
+                % dbus_object, dbus_object)
 
         if len_sigs == 0:
             return 'a' + dbus_object.signature
@@ -59,13 +70,15 @@ def signature(dbus_object, unpack=False):
         len_key_sigs = len(key_sigs)
         len_value_sigs = len(value_sigs)
 
-        if len_key_sigs != len_value_sigs:  # pragma: no cover
-            raise IntoDPValueError(dbus_object, "dbus_object",
-                                   "has bad signature")
+        if len_key_sigs != len_value_sigs:
+            raise IntoDPSignatureError(
+                "the dbus-python Dictionary object %s does not have a valid signature"
+                % dbus_object, dbus_object)  # pragma: no cover
 
-        if len_key_sigs > 1:  # pragma: no cover
-            raise IntoDPValueError(dbus_object, "dbus_object",
-                                   "has bad signature")
+        if len_key_sigs > 1:
+            raise IntoDPSignatureError(
+                "the dbus-python Dictionary object %s has different signatures for different keys"
+                % dbus_object, dbus_object)  # pragma: no cover
 
         if len_key_sigs == 0:
             return 'a{' + dbus_object.signature + '}'
@@ -112,5 +125,5 @@ def signature(dbus_object, unpack=False):
     if isinstance(dbus_object, dbus.types.UnixFd):  # pragma: no cover
         return 'h'
 
-    raise IntoDPValueError(dbus_object, "dbus_object",
-                           "has no signature")  # pragma: no cover
+    raise IntoDPSignatureError("object is not a dbus-python object type",
+                               dbus_object)

--- a/src/into_dbus_python/_xformer.py
+++ b/src/into_dbus_python/_xformer.py
@@ -21,13 +21,16 @@ import dbus
 
 from dbus_signature_pyparsing import Parser
 
-from ._errors import IntoDPValueError
+from ._errors import IntoDPError
+from ._errors import IntoDPImpossibleTokenError
+from ._errors import IntoDPSurprisingError
+from ._errors import IntoDPUnexpectedValueError
 
 
 def _wrapper(func):
     """
-    Wraps a generated function so that it catches all Type- and ValueErrors
-    and raises IntoDPValueErrors.
+    Wraps a generated function so that it catches all unexpected errors and
+    raises IntoDPSurprisingErrors.
 
     :param func: the transforming function
     """
@@ -41,9 +44,15 @@ def _wrapper(func):
         """
         try:
             return func(expr)
-        except (TypeError, ValueError) as err:
-            raise IntoDPValueError(expr, "expr", "could not be transformed") \
-               from err
+        # Allow KeyboardInterrupt error to be propagated
+        except KeyboardInterrupt as err:  # pragma: no cover
+            raise err
+        except IntoDPError as err:
+            raise err
+        except BaseException as err:
+            raise IntoDPSurprisingError(
+                "encountered a surprising error while transforming some expression",
+                expr) from err
 
     return the_func
 
@@ -154,8 +163,9 @@ class _ToDbusXformer(Parser):
                 :rtype: Array * int
                 """
                 if isinstance(a_list, dict):
-                    raise IntoDPValueError(a_list, "a_list",
-                                           "is a dict, must be an array")
+                    raise IntoDPUnexpectedValueError(
+                        "expected a list for an array but found a dict: %s" %
+                        a_list, a_list)
                 elements = [func(x) for x in a_list]
                 level = 0 if elements == [] else max(x for (_, x) in elements)
                 (obj_level, func_level) = \
@@ -168,8 +178,8 @@ class _ToDbusXformer(Parser):
 
             return (the_array_func, 'a' + sig)
 
-        raise IntoDPValueError(toks, "toks",
-                               "unexpected tokens")  # pragma: no cover
+        raise IntoDPImpossibleTokenError("Encountered unexpected tokens in the token stream") \
+                # pragma: no cover
 
     @staticmethod
     def _handle_struct(toks):
@@ -193,18 +203,16 @@ class _ToDbusXformer(Parser):
             :param int variant: variant index
             :returns: a dbus Struct of transformed values and variant level
             :rtype: Struct * int
-            :raises IntoDPValueError:
+            :raises IntoDPRuntimeError:
             """
             if isinstance(a_list, dict):
-                raise IntoDPValueError(a_list, "a_list",
-                                       "must be a simple sequence, is a dict")
+                raise IntoDPUnexpectedValueError(
+                    "expected a simple sequence for the fields of a struct but found a dict: %s"
+                    % a_list, a_list)
             if len(a_list) != len(funcs):
-                raise IntoDPValueError(
-                    a_list,
-                    "a_list",
-                    "must have exactly %u items, has %u" % \
-                      (len(funcs), len(a_list))
-                )
+                raise IntoDPUnexpectedValueError(
+                    "expected %u elements for a struct, but found %u" %
+                    (len(funcs), len(a_list)), a_list)
             elements = [f(x) for (f, x) in zip(funcs, a_list)]
             level = 0 if elements == [] else max(x for (_, x) in elements)
             (obj_level, func_level) = \
@@ -286,9 +294,6 @@ def xformers(sig):
     :param str sig: a signature
     :returns: a list of xformer functions for the given signature.
     :rtype: list of tuple of a function * str
-
-    Each function catches all TypeErrors it encounters and raises
-    corresponding IntoDPValueError exceptions.
     """
     return \
        [(_wrapper(f), l) for (f, l) in \
@@ -317,12 +322,10 @@ def xformer(signature):
         :rtype: list of object (in dbus types)
         """
         if len(objects) != len(funcs):
-            raise IntoDPValueError(
-                objects,
-                "objects",
-                "must have exactly %u items, has %u" % \
-                  (len(funcs), len(objects))
-            )
+            raise IntoDPUnexpectedValueError(
+                "expected %u items to transform but found %u" % (len(funcs),
+                                                                 len(objects)),
+                objects)
         return [x for (x, _) in (f(a) for (f, a) in zip(funcs, objects))]
 
     return the_func

--- a/src/into_dbus_python/_xformer.py
+++ b/src/into_dbus_python/_xformer.py
@@ -178,6 +178,8 @@ class _ToDbusXformer(Parser):
 
             return (the_array_func, 'a' + sig)
 
+        # This should be impossible, because a parser error is raised on
+        # an unexpected token before the handler is invoked.
         raise IntoDPImpossibleTokenError("Encountered unexpected tokens in the token stream") \
                 # pragma: no cover
 

--- a/tests/test_signature_parser.py
+++ b/tests/test_signature_parser.py
@@ -35,7 +35,9 @@ from hs_dbus_signature import dbus_signatures
 from into_dbus_python import xformer
 from into_dbus_python import xformers
 from into_dbus_python import signature
-from into_dbus_python import IntoDPError
+
+from into_dbus_python._errors import IntoDPSignatureError
+from into_dbus_python._errors import IntoDPUnexpectedValueError
 
 settings.register_profile(
     "tracing", deadline=None, suppress_health_check=[HealthCheck.too_slow])
@@ -236,10 +238,10 @@ class ParseTestCase(unittest.TestCase):
 
         xform = xformer(sig)
 
-        with self.assertRaises(IntoDPError):
+        with self.assertRaises(IntoDPUnexpectedValueError):
             xform([struct + (1, )])
 
-        with self.assertRaises(IntoDPError):
+        with self.assertRaises(IntoDPUnexpectedValueError):
             xform([struct[:-1]])
 
     @given(dbus_signatures(blacklist="hbs", exclude_dicts=True))
@@ -255,14 +257,14 @@ class ParseTestCase(unittest.TestCase):
 
         xform = xformer(sig)
 
-        with self.assertRaises(IntoDPError):
+        with self.assertRaises(IntoDPUnexpectedValueError):
             xform([{True: True}])
 
     def test_bad_array_value(self):
         """
         Verify that passing a dict for an array will raise an exception.
         """
-        with self.assertRaises(IntoDPError):
+        with self.assertRaises(IntoDPUnexpectedValueError):
             xformer('a(qq)')([dict()])
 
     def test_variant_depth(self):
@@ -288,17 +290,17 @@ class SignatureTestCase(unittest.TestCase):
         """
         Test that exceptions are properly raised.
         """
-        with self.assertRaises(IntoDPError):
+        with self.assertRaises(IntoDPSignatureError):
             signature(
                 dbus.Array(
                     [dbus.Boolean(False, variant_level=2),
                      dbus.Byte(0)],
                     signature="v"))
 
-        with self.assertRaises(IntoDPError):
+        with self.assertRaises(IntoDPSignatureError):
             signature("w")
 
-        with self.assertRaises(IntoDPError):
+        with self.assertRaises(IntoDPSignatureError):
 
             class TestObject:
                 """

--- a/tests/test_signature_parser.py
+++ b/tests/test_signature_parser.py
@@ -276,6 +276,39 @@ class ParseTestCase(unittest.TestCase):
             xformer('av')([([('v', ('b', False))])])[0],
             dbus.Array([dbus.Boolean(False, variant_level=2)], signature="v"))
 
+
+class SignatureTestCase(unittest.TestCase):
+    """
+    Tests for the signature method.
+    """
+
+    def test_exceptions(self):
+        """
+        Test that exceptions are properly raised.
+        """
+        with self.assertRaises(IntoDPError):
+            signature(
+                dbus.Array(
+                    [dbus.Boolean(False, variant_level=2),
+                     dbus.Byte(0)],
+                    signature="v"))
+
+        with self.assertRaises(IntoDPError):
+            signature("w")
+
+        with self.assertRaises(IntoDPError):
+
+            class TestObject:
+                """
+                A test  object that resembles a dbus-python object in having
+                a variant_level field, but isn't actually a dbus-python
+                object.
+                """
+                # pylint: disable=too-few-public-methods
+                variant_level = 0
+
+            signature(TestObject())
+
     @given(STRATEGY_GENERATOR.parseString('v', parseAll=True)[0])
     @settings(max_examples=50)
     def test_unpacking(self, value):

--- a/tests/test_signature_parser.py
+++ b/tests/test_signature_parser.py
@@ -24,6 +24,7 @@ import dbus
 
 from dbus_signature_pyparsing import Parser
 
+from hypothesis import example
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies
@@ -243,6 +244,7 @@ class ParseTestCase(unittest.TestCase):
 
     @given(dbus_signatures(blacklist="hbs", exclude_dicts=True))
     @settings(max_examples=100)
+    @example(sig="v")
     def test_exceptions(self, sig):
         """
         Test that an exception is raised for a dict if '{' is blacklisted.


### PR DESCRIPTION
Resolves: #10.
Resolves: #20.

This PR extends the error heirarchy for this library, but does not expose the newly created subtypes publicly. This allows a period between when they are implemented, and when they are actually part of the public interface, to allow time for any modifications that might appear to be needed. A client using this library will see no API change, just more helpful error messages than formerly.

A bug was discovered in the course of this PR: https://github.com/stratis-storage/into-dbus-python/issues/37. Addressing this bug completely has been deferred until that issue, but it was necessary to partially address it in the ```signature()``` method, where the change is documented.

This PR increases the code coverage slightly, by introducing a few more tests and removing a few "no cover" pragmas accordingly.

It uses the newly created subtypes in the tests, for more precise verification of test results.
