### PR TITLE
Fix some unnecessary comprehension lints

### DIFF
--- a/src/into_dbus_python/_signature.py
+++ b/src/into_dbus_python/_signature.py
@@ -63,7 +63,7 @@ def signature(dbus_object, unpack=False):
         if len_sigs == 0:
             return "a" + dbus_object.signature
 
-        return "a" + [x for x in sigs][0]
+        return "a" + list(sigs)[0]
 
     if isinstance(dbus_object, dbus.Struct):
         sigs = (signature(x) for x in dbus_object)
@@ -97,7 +97,7 @@ def signature(dbus_object, unpack=False):
         if len_key_sigs == 0:
             return "a{" + dbus_object.signature + "}"
 
-        return "a{" + [x for x in key_sigs][0] + [x for x in value_sigs][0] + "}"
+        return "a{" + list(key_sigs)[0] + list(value_sigs)[0] + "}"
 
     if isinstance(dbus_object, dbus.Boolean):
         return "b"

--- a/tests/test_signature_parser.py
+++ b/tests/test_signature_parser.py
@@ -54,13 +54,12 @@ OBJECT_PATH_STRATEGY = strategies.builds(
         "/".join,
         strategies.lists(
             strategies.text(
-                alphabet=[
-                    x
-                    for x in string.digits
+                alphabet=list(
+                    string.digits
                     + string.ascii_uppercase
                     + string.ascii_lowercase
                     + "_"
-                ],
+                ),
                 min_size=1,
                 max_size=10,
             ),

--- a/tests/test_signature_parser.py
+++ b/tests/test_signature_parser.py
@@ -135,7 +135,11 @@ class StrategyGenerator(Parser):
             :rtype: strategy
             """
             signature_strategy = dbus_signatures(
-                max_codes=5, min_complete_types=1, max_complete_types=1, blacklist="h"
+                max_codes=2,
+                max_struct_len=2,
+                min_complete_types=1,
+                max_complete_types=1,
+                blacklist="h",
             )
             return signature_strategy.flatmap(
                 lambda x: strategies.tuples(


### PR DESCRIPTION
Also, try to make test cases a bit smaller. With variant types, the test cases can become impossibly large, making some hypothesis tests run for an inconveniently long time.